### PR TITLE
Integrate Expo Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Valdo
+
+Valdo is a simple Instagram-like mobile application built with React Native and
+Firebase. It showcases a retro RPG pixel aesthetic using the following color
+palette:
+
+```css
+.color1 { color: #5a3938; }
+.color2 { color: #847b6d; }
+.color3 { color: #a3ab98; }
+.color4 { color: #d2d5af; }
+.color5 { color: #dfa49b; }
+```
+
+## Running the App
+
+1. Install the Expo CLI if you haven't already: `npm install -g expo-cli`.
+2. Install project dependencies with `npm install` inside `valdo-app`.
+3. Replace the Firebase configuration in `valdo-app/firebase.js` with your
+   project details.
+4. Start the project with `npm start` (or `expo start`) in the `valdo-app`
+   directory.
+5. Scan the QR code using the **Expo Go** app on your mobile device to view
+   Valdo instantly.
+
+Posts are loaded from the Firestore `posts` collection. Each document should
+contain at least an `image` URL and a `caption` string.

--- a/valdo-app/App.js
+++ b/valdo-app/App.js
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Image, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from './firebase';
+
+const Stack = createNativeStackNavigator();
+
+function FeedScreen() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const snap = await getDocs(collection(db, 'posts'));
+        const data = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        setPosts(data);
+      } catch (err) {
+        console.error('Error loading posts', err);
+      }
+    }
+    fetchPosts();
+  }, []);
+
+  const renderItem = ({ item }) => (
+    <View style={styles.card}>
+      <Image source={{ uri: item.image }} style={styles.image} />
+      <Text style={styles.caption}>{item.caption}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Valdo</Text>
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+      />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Feed" component={FeedScreen} />
+      </Stack.Navigator>
+      <StatusBar style="light" />
+    </NavigationContainer>
+  );
+}
+
+const palette = {
+  color1: '#5a3938',
+  color2: '#847b6d',
+  color3: '#a3ab98',
+  color4: '#d2d5af',
+  color5: '#dfa49b',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: palette.color3,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: palette.color5,
+    textAlign: 'center',
+    marginVertical: 16,
+  },
+  card: {
+    marginHorizontal: 16,
+    marginVertical: 8,
+    backgroundColor: palette.color4,
+    borderColor: palette.color1,
+    borderWidth: 2,
+    padding: 8,
+  },
+  image: {
+    width: '100%',
+    height: 200,
+    backgroundColor: palette.color2,
+  },
+  caption: {
+    color: palette.color1,
+    marginTop: 4,
+  },
+});

--- a/valdo-app/app.json
+++ b/valdo-app/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "Valdo",
+    "slug": "valdo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android"],
+    "jsEngine": "hermes"
+  }
+}

--- a/valdo-app/firebase.js
+++ b/valdo-app/firebase.js
@@ -1,0 +1,16 @@
+// Firebase configuration for Valdo
+// Replace the configuration with your Firebase project details.
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_PROJECT_ID.firebaseapp.com',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+  messagingSenderId: 'YOUR_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/valdo-app/package.json
+++ b/valdo-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "valdo",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.0.0",
+    "react-native": "0.71.6",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "firebase": "^9.23.0"
+  },
+  "main": "node_modules/expo/AppEntry.js"
+}


### PR DESCRIPTION
## Summary
- add Expo configuration file and update package entry point
- integrate `expo-status-bar` for a cleaner look
- enhance setup instructions to mention Expo Go and CLI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d7124df30832d82ec63c9112ee3d1